### PR TITLE
Fix URI::InvalidURIError in client.customers.checkout_url

### DIFF
--- a/lib/lago/api/resources/customer.rb
+++ b/lib/lago/api/resources/customer.rb
@@ -48,7 +48,7 @@ module Lago
 
           response = connection.post(uri)[root_name]
 
-          JSON.parse(response.to_json, object_class: OpenStruct).checkout_url
+          JSON.parse(response.to_json, object_class: OpenStruct)
         end
 
         def whitelist_params(params)

--- a/lib/lago/api/resources/customer.rb
+++ b/lib/lago/api/resources/customer.rb
@@ -46,7 +46,7 @@ module Lago
             "#{client.base_api_url}#{api_resource}/#{external_customer_id}/checkout_url",
           )
 
-          response = connection.post(uri, identifier: nil)[root_name]
+          response = connection.post(uri)[root_name]
 
           JSON.parse(response.to_json, object_class: OpenStruct).checkout_url
         end

--- a/spec/lago/api/resources/customer_spec.rb
+++ b/spec/lago/api/resources/customer_spec.rb
@@ -258,9 +258,12 @@ RSpec.describe Lago::Api::Resources::Customer do
       end
 
       it 'returns the checkout URL' do
-        checkout_url_response = resource.checkout_url(customer_external_id)
+        response = resource.checkout_url(customer_external_id)
 
-        expect(checkout_url_response).to eq('https://checkout.stripe.com/c/pay/foobar')
+        expect(response.checkout_url).to eq('https://checkout.stripe.com/c/pay/foobar')
+        expect(response.lago_customer_id).to eq(customer_external_id)
+        expect(response.external_customer_id).to eq("1a901a90-1a90-1a90-1a90-1a901a901a90")
+        expect(response.payment_provider).to eq("stripe")
       end
     end
 


### PR DESCRIPTION
# What
- Fix `URI::InvalidURIError` in `client.customers.checkout_url`
- Add tests to the function
- Fixes https://github.com/getlago/lago-ruby-client/issues/167

### Expected behavior:
The checkout_url function should successfully call the POST API and return the following object:
```
{
  "checkout_url": "https://foo.bar",
  "external_customer_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
  "lago_customer_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
  "payment_provider": "stripe"
}
```
